### PR TITLE
fix ref of HookSelect

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",
-    "build": "rollup -c",
+    "build": "yarn type-check && rollup -c",
     "build-storybook": "build-storybook",
     "push": "yarn build-storybook && git add . && git commit -m 'push - storybook - master - deploy - vercel' && git push origin master",
     "push-docs": "yarn build-storybook && git add . && git commit -m 'push - storybook - story - deploy - vercel' && git push origin story",
-    "chromatic": "npx chromatic --project-token=ce834c71045a"
+    "chromatic": "npx chromatic --project-token=ce834c71045a",
+    "type-check": "tsc --noEmit --pretty --incremental false"
   },
   "repository": {
     "type": "git",

--- a/src/components/HookSelect.tsx
+++ b/src/components/HookSelect.tsx
@@ -120,7 +120,7 @@ const Component = <T extends FieldValues>({
 						aria-label={name}
 						value={value}
 						name={name}
-						ref={ref}
+						inputRef={ref}
 						multiple={multiple}
 						onChange={callAll((e: SelectChangeEvent) => {
 							if (multiple) {


### PR DESCRIPTION
#### What's updated

- update `ref` received by Mui `Select` component to be `inputRef`

#### What's added

- add `type-check` script before building to make sure there's no type check failure

#### Issue base https://github.com/adiathasan/mui-react-hook-form-plus/issues/1



https://user-images.githubusercontent.com/46083126/192425508-d765e499-f650-4735-951e-554a5150f55a.mp4


