### PR TITLE
chore: update peerDeps to support/remove warning when installing in react 18 project

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
     "typescript": "^4.8.3"
   },
   "peerDependencies": {
-    "@babel/core": "^7.19.1",
-    "@emotion/react": "^11.10.4",
-    "@emotion/styled": "^11.10.4",
-    "@mui/material": "^5.10.5",
-    "react": "^17.0.1 || ^18.0.0",
-    "react-dom": "^17.0.1 || ^18.0.0",
-    "react-hook-form": "^7.35.0"
+    "@babel/core": "^>= ^7.19.1",
+    "@emotion/react": "^>= ^11.10.4",
+    "@emotion/styled": "^>= ^11.10.4",
+    "@mui/material": "^>= 5.0.0",
+    "react": ">= ^17.0.1",
+    "react-dom": ">= ^17.0.1",
+    "react-hook-form": ">= ^7.35.0"
   },
   "dependencies": {},
   "_id": "mui-react-hook-form-plus@1.0.1",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@mui/material": "^5.10.5",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^17.0.1 || ^18.0.0",
+    "react-dom": "^17.0.1 || ^18.0.0",
     "react-hook-form": "^7.35.0"
   },
   "dependencies": {},


### PR DESCRIPTION
#### Related issue https://github.com/adiathasan/mui-react-hook-form-plus/issues/3

#### What's updated

- update package.json react peerDeps



